### PR TITLE
Added option to hide Playables and other sections.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A collection of tweaks for hiding Shorts, disabling auto-dubbing, disabling 'Vid
 - Change the number of videos per row / Change the size of thumbnails
 - Video grid: Hide profile pictures/Decrease font size
 - Show full video titles
-- Hide Shorts, Mixes, watched videos, upcoming videos and live streams
+- Hide Shorts, Mixes, Playables, Top Live Games, Explore More Topics, watched videos, upcoming videos and live streams
 - Hide irrelevant search results (For you, People also watched, Previously watched etc.)
 - Search results in Grid view
 - More animations

--- a/src/options/tabs/homepage.html
+++ b/src/options/tabs/homepage.html
@@ -18,6 +18,14 @@
     <input type="checkbox" id="hideMixes">
   </label>
   <label>
+    <span>Playables</span>
+      <input type="checkbox" id="hidePlayables" />
+    </label>
+    <label>
+      <span>'Top Live Games'</span>
+    <input type="checkbox" id="hideTopLiveGames" />
+  </label>
+  <label>
     <span>Live streams</span>
     <button class="selectMenu openPopup rotableArrow" id="hideLiveStreams">
       <span>Off</span>
@@ -40,6 +48,10 @@
   <label>
     <span>'Latest YouTube Posts'</span>
     <input type="checkbox" id="hideLatestYouTubePosts">
+  </label>
+  <label>
+    <span>'Explore More Topics'</span>
+    <input type="checkbox" id="hideExploreMoreTopics" />
   </label>
 </section>
 <section>

--- a/src/tweaks/homepage.js
+++ b/src/tweaks/homepage.js
@@ -87,7 +87,7 @@ ytTweaks.tweaks.push(function (settings) {
     #home-chips {
       display: none;
     }
-  
+
     #frosted-glass {
       height: var(--ytd-toolbar-height) !important;
     }
@@ -117,4 +117,46 @@ ytTweaks.tweaks.push(function (settings) {
             });
         }
     }
+
+    if (settings.hidePlayables)
+        ytTweaks.sheet.textContent += `
+        mini-game-card-view-model, .ytd-mini-game-card-view-model {
+            display: none !important;
+        }
+        ytd-rich-item-renderer[is-mini-game-card-shelf] {
+            display: none !important;
+        }
+        ytd-rich-section-renderer:has(ytd-rich-item-renderer[is-mini-game-card-shelf]) {
+            display: none !important;
+        }
+        *[subtype="playables"] {
+            display: none !important;
+        }
+    `;
+
+    if (settings.hideTopLiveGames)
+        ytTweaks.sheet.textContent += `
+        mini-game-card-view-model, .ytd-mini-game-card-view-model {
+            background: red !important;
+        }
+        ytd-rich-item-renderer[is-game-card-shelf] {
+            display: none !important;
+        }
+        ytd-rich-section-renderer.style-scope:has(div.ytd-rich-section-renderer ytd-rich-shelf-renderer.style-scope #dismissible #contents-container) {
+            display: none !important;
+        }
+        ytd-horizontal-card-list-renderer[has-game-card] {
+            display: none !important;
+        }
+        ytd-item-section-renderer:has(ytd-horizontal-card-list-renderer[has-game-card]) {
+            display: none !important;
+        }
+    `;
+
+    if (settings.hideExploreMoreTopics)
+        ytTweaks.sheet.textContent += `
+       ytd-rich-section-renderer:has(#content > .ytdChipsShelfWithVideoShelfRendererHost > div > div > ytd-rich-shelf-renderer > div > div > div > ytd-rich-item-renderer[is-responsive-grid="STANDARD"]) {
+           display: none !important;
+       }
+    `;
 });


### PR DESCRIPTION
Added options to hide _Playables_, _Top Live Games_, and _Explore More Topics_ sections under __Homepage__ tab in extension popup.

If this change is merged and my other  `CHANGELOG` pull request is merged, this will be added to `CHANGELOG.md` inside of the `Unreleased > Added > Menu Options` section:
```markdown
- Hide 'Playables' section from __Homepage__ & __Search__ pages.
- Hide 'Top Live Games' section from __Homepage__ & __Search__ pages.
- Hide 'Explore More Topics' section from __Homepage__ & __Search__ pages.
```

> P.S. -
> CSS Selection is tested, but could have small errors in the future since it follows a specific element structure. It is recommended to return to this in the future and review the structure of the element on the page and create a more accurate CSS selector.